### PR TITLE
feat: get the creation date from original, set to converted

### DIFF
--- a/heic2jpg.sh
+++ b/heic2jpg.sh
@@ -2,15 +2,22 @@
 
 src=$1
 size=$(find $src -type f | grep -i '\.heic$' | wc -l)
-cnt=0
+iter=0
 
-for i in $(find $src -type f | grep -i '\.heic$')
+for fn in $(find $src -type f | grep -i '\.heic$')
 do
-	((cnt=cnt+1))
-	target=$(echo $i | sed 's/heic$/jpg/i')
-	printf "$i convert to $target\n"
-	/usr/bin/convert $i $target
-	printf " [$cnt/$size]\r"
+	iter=$((iter+1))
+	target=$(echo $fn | sed 's/heic$/jpg/i')
+	# https://www.tutorialkart.com/bash-shell-scripting/bash-date-format-options-examples/
+	FILE_DATE=$(/bin/date +%Y%m%d%H%M.%S -r ${fn})
+	printf "$iter/$size:\n"
+	printf "  File: $fn\n"
+	printf "  Creation date: $FILE_DATE\n"
+	printf "  Convert as file: $target\n"
+	/usr/bin/convert $fn $target
+	# Set the same date as the original image
+	/bin/touch -a -m -t $FILE_DATE $target
+	printf "\n\r"
 done
 
 printf "\n=== Finished ===\n"


### PR DESCRIPTION
When converting files, it is likely because we want to import into a photo management system. We might still want to have the original date of creation. This reads the date, and sets it on the new converted image.

## Screenshots

### Running output
![Screen Shot 2022-06-04 at 15 46 45](https://user-images.githubusercontent.com/296940/172023453-0a1a9928-76dc-4eef-846c-36641e4c4e56.png)

### Checking file dates
![Screen Shot 2022-06-04 at 15 50 40](https://user-images.githubusercontent.com/296940/172023516-4ec083d0-5b91-41dc-9441-5a8e3381addf.png)

